### PR TITLE
Adds rounded corners to UINavigationBar

### DIFF
--- a/PrettyKit/PrettyNavigationBar.h
+++ b/PrettyKit/PrettyNavigationBar.h
@@ -72,4 +72,14 @@
  By default is a blue tone. */
 @property (nonatomic, retain) UIColor *bottomLineColor;
 
+/** Specifies the background color for the rounded corners.
+ 
+ By default is a black tone. */
+@property (nonatomic, retain) UIColor *roundedCornerColor;
+
+/** Specifies the radius for the rounded corners.
+ 
+ By default it is 0.0 which means there is no rounded corners */
+@property (readwrite) CGFloat roundedCornerRadius;
+
 @end

--- a/PrettyKit/PrettyNavigationBar.m
+++ b/PrettyKit/PrettyNavigationBar.m
@@ -30,9 +30,10 @@
 #import "PrettyNavigationBar.h"
 #import <QuartzCore/QuartzCore.h>
 #import "PrettyDrawing.h"
+#import <math.h>
 
 @implementation PrettyNavigationBar
-@synthesize shadowOpacity, gradientEndColor, gradientStartColor, topLineColor, bottomLineColor;
+@synthesize shadowOpacity, gradientEndColor, gradientStartColor, topLineColor, bottomLineColor, roundedCornerRadius, roundedCornerColor;
 
 
 #define default_shadow_opacity 0.5
@@ -41,7 +42,7 @@
 #define default_top_line_color          [UIColor colorWithHex:0x84B7D5]
 #define default_bottom_line_color       [UIColor colorWithHex:0x186399]
 #define default_tint_color              [UIColor colorWithHex:0x3D89BF]
-
+#define default_roundedcorner_color     [UIColor blackColor]
 
 - (void)dealloc {
     self.gradientStartColor = nil;
@@ -61,6 +62,8 @@
     self.topLineColor = default_top_line_color;
     self.bottomLineColor = default_bottom_line_color;
     self.tintColor = default_tint_color;
+    self.roundedCornerColor = default_roundedcorner_color;
+    self.roundedCornerRadius = 0.0;
 }
 
 - (id)initWithCoder:(NSCoder *)coder {
@@ -89,7 +92,24 @@
 }
 
 
+-(void) drawLeftRoundedCornerAtPoint:(CGPoint)point withRadius:(CGFloat)radius withTransformation:(CGAffineTransform)transform {
+    
+    // create the path. has to be done this way to allow use of the transform
+    CGMutablePathRef path = CGPathCreateMutable();
+    CGPathMoveToPoint(path, &transform, point.x, point.y);
+    CGPathAddLineToPoint(path, &transform, point.x, point.y + radius);
+    CGPathAddArc(path, &transform, point.x + radius, point.y + radius, radius, (180) * M_PI/180, (-90) * M_PI/180, 0);
+    CGPathAddLineToPoint(path, &transform, point.x, point.y);
+    
+    // fill the path to create the illusion that the corner is rounded
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextAddPath(context, path);
+    CGContextSetFillColorWithColor(context, [self.roundedCornerColor CGColor]);
+    CGContextFillPath(context);
 
+    // appropriate memory management
+    CGPathRelease(path);
+}
 
 - (void) drawTopLine:(CGRect)rect {
     [PrettyDrawing drawLineAtPosition:LinePositionTop rect:rect color:self.topLineColor];
@@ -107,6 +127,14 @@
     [PrettyDrawing drawGradient:rect fromColor:self.gradientStartColor toColor:self.gradientEndColor];
     [self drawTopLine:rect];        
     [self drawBottomLine:rect];
+    
+    if (self.roundedCornerRadius > 0) {
+        // draw the left rounded corner with a transform of 0 because nothing should be changed
+        [self drawLeftRoundedCornerAtPoint:CGPointMake(0, 0) withRadius:self.roundedCornerRadius withTransformation:CGAffineTransformMakeRotation(0)];
+        
+        // draw the right rounded corner with a 90degree transform. this means the x and y coords are flipped which means the point must also flip
+        [self drawLeftRoundedCornerAtPoint:CGPointMake(0, -self.frame.size.width) withRadius:self.roundedCornerRadius withTransformation:CGAffineTransformMakeRotation((90) * M_PI/180)];
+    }
 }
 
 


### PR DESCRIPTION
Same as how Path has rounded corners for its navigation bar.

Achieves this by drawing an arc with an appropriate background color (most of the time black to match the black status bar) and filling it. Repeat for the other corner.

To use, just set the corner radius for the uinavigationbar. optionally you can set the background color its supposed to be set to.
