### PR TITLE
Prefix category methods to avoid potential namespace collisions

### DIFF
--- a/PrettyExample/PlainExample.m
+++ b/PrettyExample/PlainExample.m
@@ -10,8 +10,8 @@
 #import "PrettyKit.h"
 
 
-#define start_color [UIColor colorWithHex:0xEEEEEE]
-#define end_color [UIColor colorWithHex:0xDEDEDE]
+#define start_color [UIColor pretty_colorWithHex:0xEEEEEE]
+#define end_color [UIColor pretty_colorWithHex:0xDEDEDE]
 
 @implementation PlainExample
 
@@ -36,10 +36,10 @@
 - (void) customizeNavBar {
     PrettyNavigationBar *navBar = (PrettyNavigationBar *)self.navigationController.navigationBar;
     
-    navBar.topLineColor = [UIColor colorWithHex:0xFF1000];
-    navBar.gradientStartColor = [UIColor colorWithHex:0xDD0000];
-    navBar.gradientEndColor = [UIColor colorWithHex:0xAA0000];    
-    navBar.bottomLineColor = [UIColor colorWithHex:0x990000];   
+    navBar.topLineColor = [UIColor pretty_colorWithHex:0xFF1000];
+    navBar.gradientStartColor = [UIColor pretty_colorWithHex:0xDD0000];
+    navBar.gradientEndColor = [UIColor pretty_colorWithHex:0xAA0000];
+    navBar.bottomLineColor = [UIColor pretty_colorWithHex:0x990000];
     navBar.tintColor = navBar.gradientEndColor;
     navBar.roundedCornerRadius = 8;
 }
@@ -63,7 +63,7 @@
 
     self.navigationItem.rightBarButtonItem = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCompose target:nil action:nil] autorelease];
 
-    [self.tableView dropShadows];
+    [self.tableView pretty_dropShadows];
     [self customizeNavBar];
 }
 

--- a/PrettyKit/Cells/PrettyTableViewCell.m
+++ b/PrettyKit/Cells/PrettyTableViewCell.m
@@ -38,11 +38,11 @@
 
 #define default_radius          10
 
-#define default_border_color                    [UIColor colorWithHex:0xBCBCBC]
-#define default_separator_color                 [UIColor colorWithHex:0xCDCDCD] 
+#define default_border_color                    [UIColor pretty_colorWithHex:0xBCBCBC]
+#define default_separator_color                 [UIColor pretty_colorWithHex:0xCDCDCD] 
 
-#define default_selection_gradient_start_color  [UIColor colorWithHex:0x0089F9]
-#define default_selection_gradient_end_color    [UIColor colorWithHex:0x0054EA]
+#define default_selection_gradient_start_color  [UIColor pretty_colorWithHex:0x0089F9]
+#define default_selection_gradient_end_color    [UIColor pretty_colorWithHex:0x0054EA]
 
 
 typedef enum {

--- a/PrettyKit/PrettyDrawing.h
+++ b/PrettyKit/PrettyDrawing.h
@@ -72,6 +72,12 @@ typedef enum {
 /** This category adds a set of methods to UIView class. */
 @interface UIView (PrettyKit)
 
+/** Drops a shadow with the given opacity.
+ 
+ @warning This method uses the UILayer shadow properties.
+ @warning This method is deprecated in favor of `pretty_dropShadowWithOpacity:`.
+ */
+- (void) dropShadowWithOpacity:(float)opacity __attribute__((deprecated));
 
 /** Drops a shadow with the given opacity.
  
@@ -84,6 +90,14 @@ typedef enum {
 
 /** This category adds a set of methods to UIColor class. */
 @interface UIColor (PrettyKit)
+
+/** Returns an autoreleased UIColor instance with the hexadecimal color.
+ 
+ @param hex A color in hexadecimal notation: `0xCCCCCC`, `0xF7F7F7`, etc.
+ @warning This method is deprecated in favor of `pretty_colorWithHex:`.
+ 
+ @return A new autoreleased UIColor instance. */
++ (UIColor *) colorWithHex:(int)hex __attribute__((deprecated));
 
 /** Returns an autoreleased UIColor instance with the hexadecimal color.
  

--- a/PrettyKit/PrettyDrawing.h
+++ b/PrettyKit/PrettyDrawing.h
@@ -77,7 +77,7 @@ typedef enum {
  
  @warning This method uses the UILayer shadow properties.
  */
-- (void) dropShadowWithOpacity:(float)opacity;
+- (void) pretty_dropShadowWithOpacity:(float)opacity;
 
 @end
 
@@ -90,6 +90,6 @@ typedef enum {
  @param hex A color in hexadecimal notation: `0xCCCCCC`, `0xF7F7F7`, etc.
  
  @return A new autoreleased UIColor instance. */
-+ (UIColor *) colorWithHex:(int)hex;
++ (UIColor *) pretty_colorWithHex:(int)hex;
 
 @end

--- a/PrettyKit/PrettyDrawing.m
+++ b/PrettyKit/PrettyDrawing.m
@@ -118,6 +118,10 @@
 
 @implementation UIView (PrettyKit)
 
+- (void) dropShadowWithOpacity:(float)opacity {
+    [self pretty_dropShadowWithOpacity:opacity];
+}
+
 - (void) pretty_dropShadowWithOpacity:(float)opacity {
     self.layer.masksToBounds = NO;
     self.layer.shadowOffset = CGSizeMake(0, 0);
@@ -131,6 +135,10 @@
 @implementation UIColor (PrettyKit)
 
 // http://stackoverflow.com/questions/1560081/how-can-i-create-a-uicolor-from-a-hex-string
++ (UIColor *) colorWithHex:(int)hex {
+    return [self pretty_colorWithHex:hex];
+}
+
 + (UIColor *) pretty_colorWithHex:(int)hex {
     return [UIColor colorWithRed:((float)((hex & 0xFF0000) >> 16))/255.0
                            green:((float)((hex & 0xFF00) >> 8))/255.0 

--- a/PrettyKit/PrettyDrawing.m
+++ b/PrettyKit/PrettyDrawing.m
@@ -118,7 +118,7 @@
 
 @implementation UIView (PrettyKit)
 
-- (void) dropShadowWithOpacity:(float)opacity {
+- (void) pretty_dropShadowWithOpacity:(float)opacity {
     self.layer.masksToBounds = NO;
     self.layer.shadowOffset = CGSizeMake(0, 0);
     self.layer.shadowOpacity = opacity;
@@ -131,7 +131,7 @@
 @implementation UIColor (PrettyKit)
 
 // http://stackoverflow.com/questions/1560081/how-can-i-create-a-uicolor-from-a-hex-string
-+ (UIColor *) colorWithHex:(int)hex {
++ (UIColor *) pretty_colorWithHex:(int)hex {
     return [UIColor colorWithRed:((float)((hex & 0xFF0000) >> 16))/255.0
                            green:((float)((hex & 0xFF00) >> 8))/255.0 
                             blue:((float)(hex & 0xFF))/255.0 alpha:1.0];

--- a/PrettyKit/PrettyNavigationBar.m
+++ b/PrettyKit/PrettyNavigationBar.m
@@ -37,11 +37,11 @@
 
 
 #define default_shadow_opacity 0.5
-#define default_gradient_end_color      [UIColor colorWithHex:0x297CB7]
-#define default_gradient_start_color    [UIColor colorWithHex:0x53A4DE]
-#define default_top_line_color          [UIColor colorWithHex:0x84B7D5]
-#define default_bottom_line_color       [UIColor colorWithHex:0x186399]
-#define default_tint_color              [UIColor colorWithHex:0x3D89BF]
+#define default_gradient_end_color      [UIColor pretty_colorWithHex:0x297CB7]
+#define default_gradient_start_color    [UIColor pretty_colorWithHex:0x53A4DE]
+#define default_top_line_color          [UIColor pretty_colorWithHex:0x84B7D5]
+#define default_bottom_line_color       [UIColor pretty_colorWithHex:0x186399]
+#define default_tint_color              [UIColor pretty_colorWithHex:0x3D89BF]
 #define default_roundedcorner_color     [UIColor blackColor]
 
 - (void)dealloc {
@@ -124,7 +124,7 @@
 - (void) drawRect:(CGRect)rect {
     [super drawRect:rect];
     
-    [self dropShadowWithOpacity:self.shadowOpacity];
+    [self pretty_dropShadowWithOpacity:self.shadowOpacity];
     [PrettyDrawing drawGradient:rect fromColor:self.gradientStartColor toColor:self.gradientEndColor];
     [self drawTopLine:rect];        
     [self drawBottomLine:rect];

--- a/PrettyKit/PrettyShadowPlainTableview.h
+++ b/PrettyKit/PrettyShadowPlainTableview.h
@@ -78,6 +78,6 @@ typedef enum {
  
  Shadows will be included __only__ if the tableView's style is plain.
  */
-- (void) dropShadows;
+- (void) pretty_dropShadows;
 
 @end

--- a/PrettyKit/PrettyShadowPlainTableview.h
+++ b/PrettyKit/PrettyShadowPlainTableview.h
@@ -74,6 +74,16 @@ typedef enum {
 
 /** Configures automatically the receiver tableView by dropping a shadow in both
  header and footer. It will also change the tableView's `contentInset` according
+ to the shadows' height.
+ 
+ Shadows will be included __only__ if the tableView's style is plain.
+ 
+ @warning This method is deprecated in favor of `pretty_dropShadows`.
+ */
+- (void) dropShadows __attribute__((deprecated));
+
+/** Configures automatically the receiver tableView by dropping a shadow in both
+ header and footer. It will also change the tableView's `contentInset` according
  to the shadows' height. 
  
  Shadows will be included __only__ if the tableView's style is plain.

--- a/PrettyKit/PrettyShadowPlainTableview.m
+++ b/PrettyKit/PrettyShadowPlainTableview.m
@@ -92,6 +92,11 @@
 
 @implementation UITableView (PrettyKitTableViewShadows)
 
+- (void) dropShadows
+{
+    [self pretty_dropShadows];
+}
+
 - (void) pretty_dropShadows
 {
     if (self.style == UITableViewStylePlain)

--- a/PrettyKit/PrettyShadowPlainTableview.m
+++ b/PrettyKit/PrettyShadowPlainTableview.m
@@ -92,7 +92,7 @@
 
 @implementation UITableView (PrettyKitTableViewShadows)
 
-- (void) dropShadows
+- (void) pretty_dropShadows
 {
     if (self.style == UITableViewStylePlain)
     {

--- a/PrettyKit/PrettyTabBar.m
+++ b/PrettyKit/PrettyTabBar.m
@@ -30,9 +30,9 @@
 #import "PrettyTabBar.h"
 #import "PrettyDrawing.h"
 
-#define default_gradient_start_color [UIColor colorWithHex:0x444444]
-#define default_gradient_end_color [UIColor colorWithHex:0x060606]
-#define default_separator_line_color [UIColor colorWithHex:0x666666]
+#define default_gradient_start_color [UIColor pretty_colorWithHex:0x444444]
+#define default_gradient_end_color [UIColor pretty_colorWithHex:0x060606]
+#define default_separator_line_color [UIColor pretty_colorWithHex:0x666666]
 
 @implementation PrettyTabBar
 @synthesize gradientStartColor, gradientEndColor, separatorLineColor;

--- a/PrettyKit/PrettyToolbar.m
+++ b/PrettyKit/PrettyToolbar.m
@@ -30,11 +30,11 @@
 @synthesize shadowOpacity, gradientEndColor, gradientStartColor, topLineColor, bottomLineColor;
 
 #define default_shadow_opacity 0.5
-#define default_gradient_end_color      [UIColor colorWithHex:0x297CB7]
-#define default_gradient_start_color    [UIColor colorWithHex:0x53A4DE]
-#define default_top_line_color          [UIColor colorWithHex:0x4F94C4]
-#define default_bottom_line_color       [UIColor colorWithHex:0x186399]
-#define default_tint_color              [UIColor colorWithHex:0x3D89BF]
+#define default_gradient_end_color      [UIColor pretty_colorWithHex:0x297CB7]
+#define default_gradient_start_color    [UIColor pretty_colorWithHex:0x53A4DE]
+#define default_top_line_color          [UIColor pretty_colorWithHex:0x4F94C4]
+#define default_bottom_line_color       [UIColor pretty_colorWithHex:0x186399]
+#define default_tint_color              [UIColor pretty_colorWithHex:0x3D89BF]
 
 - (void)dealloc {
     self.gradientStartColor = nil;
@@ -95,7 +95,7 @@
 - (void) drawRect:(CGRect)rect {
     [super drawRect:rect];
     
-    [self dropShadowWithOpacity:self.shadowOpacity];
+    [self pretty_dropShadowWithOpacity:self.shadowOpacity];
     [PrettyDrawing drawGradient:rect fromColor:self.gradientStartColor toColor:self.gradientEndColor];
     [self drawTopLine:rect];        
     [self drawBottomLine:rect];


### PR DESCRIPTION
Using `PrettyKit` alongside [SSToolkit](https://github.com/soffes/sstoolkit) results in a naming collision between publicly visible categories on `UIColor`. `[UIColor colorWithHex:]` in `PrettyKit` expects an `int` as a parameter, whereas `SSToolkit` expects an `NSString`. Since both `PrettyKit` and `SSToolkit` are popular, it's reasonable to assume more will encounter this incompatibility. This pull request prefixes category methods in `PrettyKit` with `pretty_`, avoiding future namespace collisions.
